### PR TITLE
define database schema and provide accessor methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,11 +25,15 @@ members = [
 ]
 
 [workspace.dependencies]
+imbibe-domain = { path = "./crates/imbibe-domain" }
 imbibe-macros = { path = "./crates/imbibe-macros" }
 
 bon = "3.5"
 bytes = "1"
 cosmrs = "0.22"
+futures = "0.3"
 jiff = "0.2"
 serde = "1"
 thiserror = "2"
+tracing = "0.1"
+url = "2"

--- a/crates/imbibe-persistence/Cargo.toml
+++ b/crates/imbibe-persistence/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "imbibe-persistence"
+version.workspace = true
+edition.workspace = true
+readme.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[features]
+default = []
+bundled = [
+  "openssl-sys/vendored",
+  "pq-sys/bundled",
+]
+
+[dependencies]
+bigdecimal = "0.4"
+bon = { workspace = true }
+chrono = "0.4"
+cosmrs = { workspace = true }
+diesel = { version = "2", features = ["chrono", "postgres", "numeric", "serde_json"] }
+diesel-async = { version = "0.5", features = ["deadpool", "postgres"] }
+futures = { workspace = true }
+imbibe-domain = { workspace = true }
+jiff = { workspace = true }
+openssl-sys = { version = "*", optional = true }
+pq-sys = { version = "*", optional = true }
+thiserror = { workspace = true }
+serde_json = "1"
+tracing = { workspace = true }
+url = { workspace = true }

--- a/crates/imbibe-persistence/README.md
+++ b/crates/imbibe-persistence/README.md
@@ -1,0 +1,7 @@
+# imbibe-persistence
+
+This crate details the database model of the information extracted from a block and its constituent transactions.
+
+It uses [diesel](diesel.rs) and [postgresql](postgresql.org) to provide the read and write methods against the databse.
+
+The sql files defining the schema for block and tx can be found in `migrations`.

--- a/crates/imbibe-persistence/diesel.toml
+++ b/crates/imbibe-persistence/diesel.toml
@@ -1,0 +1,9 @@
+# For documentation on how to configure this file,
+# see https://diesel.rs/guides/configuring-diesel-cli
+
+[print_schema]
+file = "src/schema.rs"
+custom_type_derives = ["diesel::query_builder::QueryId", "Clone"]
+
+[migrations_directory]
+dir = "migrations"

--- a/crates/imbibe-persistence/migrations/00000000000000_diesel_initial_setup/down.sql
+++ b/crates/imbibe-persistence/migrations/00000000000000_diesel_initial_setup/down.sql
@@ -1,0 +1,6 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+DROP FUNCTION IF EXISTS diesel_manage_updated_at(_tbl regclass);
+DROP FUNCTION IF EXISTS diesel_set_updated_at();

--- a/crates/imbibe-persistence/migrations/00000000000000_diesel_initial_setup/up.sql
+++ b/crates/imbibe-persistence/migrations/00000000000000_diesel_initial_setup/up.sql
@@ -1,0 +1,36 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+
+
+
+-- Sets up a trigger for the given table to automatically set a column called
+-- `updated_at` whenever the row is modified (unless `updated_at` was included
+-- in the modified columns)
+--
+-- # Example
+--
+-- ```sql
+-- CREATE TABLE users (id SERIAL PRIMARY KEY, updated_at TIMESTAMP NOT NULL DEFAULT NOW());
+--
+-- SELECT diesel_manage_updated_at('users');
+-- ```
+CREATE OR REPLACE FUNCTION diesel_manage_updated_at(_tbl regclass) RETURNS VOID AS $$
+BEGIN
+    EXECUTE format('CREATE TRIGGER set_updated_at BEFORE UPDATE ON %s
+                    FOR EACH ROW EXECUTE PROCEDURE diesel_set_updated_at()', _tbl);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION diesel_set_updated_at() RETURNS trigger AS $$
+BEGIN
+    IF (
+        NEW IS DISTINCT FROM OLD AND
+        NEW.updated_at IS NOT DISTINCT FROM OLD.updated_at
+    ) THEN
+        NEW.updated_at := current_timestamp;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/crates/imbibe-persistence/migrations/2025-01-01-000000_create_block/down.sql
+++ b/crates/imbibe-persistence/migrations/2025-01-01-000000_create_block/down.sql
@@ -1,0 +1,4 @@
+-- This file should undo anything in `up.sql`
+--
+
+DROP TABLE IF EXISTS block;

--- a/crates/imbibe-persistence/migrations/2025-01-01-000000_create_block/up.sql
+++ b/crates/imbibe-persistence/migrations/2025-01-01-000000_create_block/up.sql
@@ -1,0 +1,49 @@
+CREATE TABLE IF NOT EXISTS block (
+    height BIGINT PRIMARY KEY,
+
+    block_hash BYTEA NOT NULL UNIQUE,
+
+    -- Header fields
+    chain_id TEXT NOT NULL,
+    time TIMESTAMPTZ NOT NULL,
+    app_hash BYTEA NOT NULL,
+    validators_hash BYTEA NOT NULL,
+    next_validators_hash BYTEA NOT NULL,
+    consensus_hash BYTEA NOT NULL,
+    proposer BYTEA NOT NULL,
+
+    gas_used BIGINT NOT NULL,
+    last_commit_hash BYTEA,
+    data_hash BYTEA,
+    last_results_hash BYTEA,
+    evidence_hash BYTEA,
+
+    -- Constraints for SHA256 (32 bytes) and address (20 bytes)
+    CONSTRAINT chk_block_hash_len CHECK (
+        block_hash IS NULL OR OCTET_LENGTH(block_hash) = 32
+    ),
+    CONSTRAINT chk_validators_hash_len CHECK (
+        OCTET_LENGTH(validators_hash) = 32
+    ),
+    CONSTRAINT chk_next_validators_hash_len CHECK (
+        OCTET_LENGTH(next_validators_hash) = 32
+    ),
+    CONSTRAINT chk_consensus_hash_len CHECK (
+        OCTET_LENGTH(consensus_hash) = 32
+    ),
+    CONSTRAINT chk_proposer_len CHECK (
+        OCTET_LENGTH(proposer) = 20
+    ),
+    CONSTRAINT chk_last_commit_hash_len CHECK (
+        last_commit_hash IS NULL OR OCTET_LENGTH(last_commit_hash) = 32
+    ),
+    CONSTRAINT chk_data_hash_len CHECK (
+        data_hash IS NULL OR OCTET_LENGTH(data_hash) = 32
+    ),
+    CONSTRAINT chk_last_results_hash_len CHECK (
+        last_results_hash IS NULL OR OCTET_LENGTH(last_results_hash) = 32
+    ),
+    CONSTRAINT chk_evidence_hash_len CHECK (
+        evidence_hash IS NULL OR OCTET_LENGTH(evidence_hash) = 32
+    )
+);

--- a/crates/imbibe-persistence/migrations/2025-01-01-000001_create_tx/down.sql
+++ b/crates/imbibe-persistence/migrations/2025-01-01-000001_create_tx/down.sql
@@ -1,0 +1,6 @@
+-- This file should undo anything in `up.sql`
+
+DROP TABLE IF EXISTS signature;
+DROP TABLE IF EXISTS msg;
+DROP TABLE IF EXISTS fee;
+DROP TABLE IF EXISTS tx;

--- a/crates/imbibe-persistence/migrations/2025-01-01-000001_create_tx/up.sql
+++ b/crates/imbibe-persistence/migrations/2025-01-01-000001_create_tx/up.sql
@@ -1,0 +1,96 @@
+CREATE TABLE IF NOT EXISTS tx (
+    block_height BIGINT NOT NULL REFERENCES block(height),
+    tx_idx_in_block BIGINT NOT NULL,
+
+    tx_hash BYTEA NOT NULL UNIQUE,
+
+    memo TEXT,
+    timeout_height BIGINT,
+
+    signers JSONB NOT NULL,
+
+    payer BYTEA NOT NULL,
+    granter BYTEA,
+
+    gas_limit BIGINT NOT NULL,
+    gas_wanted BIGINT NOT NULL,
+    gas_used BIGINT NOT NULL,
+
+    code INTEGER NOT NULL,
+    codespace TEXT,
+
+    data_bz BYTEA,
+    tx_bz BYTEA NOT NULL,
+
+    PRIMARY KEY (block_height, tx_idx_in_block),
+
+    CONSTRAINT chk_tx_hash_len CHECK (
+        OCTET_LENGTH(tx_hash) = 32
+    ),
+    CONSTRAINT chk_memo_not_empty CHECK (
+        memo IS NULL OR LENGTH(memo) > 0
+    ),
+    CONSTRAINT chk_timeout_height_positive CHECK (
+      timeout_height IS NULL OR timeout_height > 0  
+    ),
+    CONSTRAINT chk_payer_len CHECK (
+        OCTET_LENGTH(payer) = 20
+    ),
+    CONSTRAINT chk_granter_len CHECK (
+        granter IS NULL OR OCTET_LENGTH(granter) = 20
+    ),
+    CONSTRAINT chk_codespace_not_empty CHECK (
+        codespace IS NULL OR LENGTH(codespace) > 0
+    ),
+    CONSTRAINT chk_data_bz_not_empty CHECK (
+        data_bz IS NULL OR OCTET_LENGTH(data_bz) > 0
+    ),
+    CONSTRAINT chk_tx_bz_not_empty CHECK (
+        OCTET_LENGTH(tx_bz) > 0
+    )
+);
+
+CREATE TABLE IF NOT EXISTS signature (
+    block_height BIGINT NOT NULL REFERENCES block(height),
+    tx_idx_in_block BIGINT NOT NULL,
+    signature_idx_in_tx BIGINT NOT NULL,
+
+    bz BYTEA NOT NULL,
+
+    PRIMARY KEY (block_height, tx_idx_in_block, signature_idx_in_tx),
+    FOREIGN KEY (block_height, tx_idx_in_block) REFERENCES tx(block_height, tx_idx_in_block),
+
+    CONSTRAINT chk_bz_not_empty CHECK (
+        OCTET_LENGTH(bz) > 0
+    )        
+);
+
+CREATE TABLE IF NOT EXISTS fee (
+    block_height BIGINT NOT NULL REFERENCES block(height),
+    tx_idx_in_block BIGINT NOT NULL,
+    fee_idx_in_tx BIGINT NOT NULL,
+
+    amount NUMERIC(39, 0) NOT NULL,
+    denom TEXT NOT NULL,
+
+    PRIMARY KEY (block_height, tx_idx_in_block, fee_idx_in_tx),
+    FOREIGN KEY (block_height, tx_idx_in_block) REFERENCES tx(block_height, tx_idx_in_block),
+
+    CONSTRAINT chk_amount_is_valid_u128 CHECK (
+        amount >= 0
+        AND
+        amount <= 340282366920938463463374607431768211455 -- u128 max value
+    )
+);
+
+CREATE TABLE IF NOT EXISTS msg (
+    block_height BIGINT NOT NULL REFERENCES block(height),
+    tx_idx_in_block BIGINT NOT NULL,
+    msg_idx_in_tx BIGINT NOT NULL,
+
+    type_url TEXT NOT NULL,
+    value BYTEA NOT NULL,
+
+    PRIMARY KEY (block_height, tx_idx_in_block, msg_idx_in_tx),
+    FOREIGN KEY (block_height, tx_idx_in_block) REFERENCES tx(block_height, tx_idx_in_block)
+);

--- a/crates/imbibe-persistence/src/lib.rs
+++ b/crates/imbibe-persistence/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod pool;
+pub mod store;
+
+mod record;
+mod schema;

--- a/crates/imbibe-persistence/src/pool.rs
+++ b/crates/imbibe-persistence/src/pool.rs
@@ -1,0 +1,22 @@
+pub use diesel_async::pooled_connection::deadpool::PoolError;
+
+use core::num::NonZeroUsize;
+
+use diesel_async::{
+	AsyncPgConnection,
+	pooled_connection::{
+		AsyncDieselConnectionManager,
+		deadpool::{BuildError, Object, Pool},
+	},
+};
+use url::Url;
+
+pub type DbPool = Pool<AsyncPgConnection>;
+pub type DbConn = Object<AsyncPgConnection>;
+
+pub async fn establish_pool(url: Url, max_size: NonZeroUsize) -> Result<DbPool, BuildError> {
+	let pool =
+		Pool::builder(AsyncDieselConnectionManager::new(url)).max_size(max_size.get()).build()?;
+
+	Ok(pool)
+}

--- a/crates/imbibe-persistence/src/record.rs
+++ b/crates/imbibe-persistence/src/record.rs
@@ -1,0 +1,23 @@
+pub mod error;
+pub mod insert;
+pub mod select;
+
+use chrono::{DateTime, Utc};
+use jiff::Timestamp;
+
+fn jiff_to_chrono(jiff: &Timestamp) -> Option<DateTime<Utc>> {
+	let nanos = jiff.as_nanosecond();
+
+	const NANOS_IN_ONE_SEC: i128 = 1_000_000_000;
+
+	let secs = (nanos / NANOS_IN_ONE_SEC).try_into().ok()?;
+	let sub_nanos = (nanos % NANOS_IN_ONE_SEC).try_into().ok()?;
+
+	DateTime::from_timestamp(secs, sub_nanos)
+}
+
+fn chrono_to_jiff(chrono: &DateTime<Utc>) -> Timestamp {
+	let secs = chrono.timestamp();
+	let sub_nanos = chrono.timestamp_subsec_nanos().try_into().expect("sub nanos must be valid");
+	Timestamp::new(secs, sub_nanos).expect("valid datetime must yield valid timestamp")
+}

--- a/crates/imbibe-persistence/src/record/error.rs
+++ b/crates/imbibe-persistence/src/record/error.rs
@@ -1,0 +1,31 @@
+use core::{array::TryFromSliceError, num::TryFromIntError};
+
+use cosmrs::ErrorReport;
+
+#[non_exhaustive]
+#[derive(Debug, thiserror::Error)]
+pub enum InvalidValueError {
+	#[error(transparent)]
+	IntConversionError(#[from] TryFromIntError),
+
+	#[error("amount error: amount must be valid u128")]
+	AmountError,
+
+	#[error("cosmrs error: {0}")]
+	Cosmrs(#[from] ErrorReport),
+
+	#[error("empty error: value must be non empty")]
+	Empty,
+
+	#[error("slice error: {0}")]
+	Slice(#[from] TryFromSliceError),
+
+	#[error("invalid time value")]
+	Time,
+
+	#[error("json error: {0}")]
+	Json(#[from] serde_json::Error),
+
+	#[error("other error: {0}")]
+	Other(String),
+}

--- a/crates/imbibe-persistence/src/record/insert.rs
+++ b/crates/imbibe-persistence/src/record/insert.rs
@@ -1,0 +1,146 @@
+use bigdecimal::BigDecimal;
+use bon::Builder;
+use chrono::{DateTime, Utc};
+use cosmrs::{Any, tx::SignerPublicKey};
+use diesel::prelude::Insertable;
+use imbibe_domain::{Address, block::Block, tx::Tx};
+use serde_json::Value;
+
+use crate::schema;
+
+use super::error::InvalidValueError;
+
+#[derive(Debug, Insertable, Builder)]
+#[diesel(table_name = schema::block)]
+pub struct NewBlockRecord<'a> {
+	height: i64,
+	block_hash: &'a [u8],
+	chain_id: &'a str,
+	time: DateTime<Utc>,
+	app_hash: &'a [u8],
+	validators_hash: &'a [u8],
+	next_validators_hash: &'a [u8],
+	consensus_hash: &'a [u8],
+	proposer: &'a [u8],
+	gas_used: i64,
+	last_commit_hash: Option<&'a [u8]>,
+	data_hash: Option<&'a [u8]>,
+	last_results_hash: Option<&'a [u8]>,
+	evidence_hash: Option<&'a [u8]>,
+}
+
+#[derive(Insertable, Builder)]
+#[diesel(table_name = schema::tx)]
+pub struct NewTxRecord<'a> {
+	block_height: i64,
+	tx_idx_in_block: i64,
+
+	tx_hash: &'a [u8],
+
+	memo: Option<&'a str>,
+	timeout_height: Option<i64>,
+
+	signers: Value,
+	payer: &'a [u8],
+	granter: Option<&'a [u8]>,
+	gas_limit: i64,
+	gas_wanted: i64,
+	gas_used: i64,
+
+	code: i32,
+	codespace: Option<&'a str>,
+	data_bz: Option<&'a [u8]>,
+	tx_bz: &'a [u8],
+}
+
+#[derive(Insertable, Builder)]
+#[diesel(table_name = schema::signature)]
+pub struct NewSignatureRecord<'a> {
+	block_height: i64,
+	tx_idx_in_block: i64,
+	signature_idx_in_tx: i64,
+
+	bz: &'a [u8],
+}
+
+#[derive(Insertable, Builder)]
+#[diesel(table_name = schema::fee)]
+pub struct NewFeeRecord<'a> {
+	block_height: i64,
+	tx_idx_in_block: i64,
+	fee_idx_in_tx: i64,
+
+	amount: BigDecimal,
+	denom: &'a str,
+}
+
+#[derive(Insertable, Builder)]
+#[diesel(table_name = schema::msg)]
+pub struct NewMsgRecord<'a> {
+	block_height: i64,
+	tx_idx_in_block: i64,
+	msg_idx_in_tx: i64,
+
+	type_url: &'a str,
+	value: &'a [u8],
+}
+
+impl<'a> TryFrom<&'a Block> for NewBlockRecord<'a> {
+	type Error = InvalidValueError;
+
+	fn try_from(block: &'a Block) -> Result<Self, Self::Error> {
+		let record = Self::builder()
+			.height(block.header().height().try_into()?)
+			.block_hash(block.hash().get())
+			.chain_id(block.header().chain_id())
+			.time(super::jiff_to_chrono(block.header().time()).ok_or(InvalidValueError::Time)?)
+			.app_hash(block.header().app_hash().get())
+			.validators_hash(block.header().validators_hash().get())
+			.next_validators_hash(block.header().next_validators_hash().get())
+			.consensus_hash(block.header().consensus_hash().get())
+			.proposer(block.header().proposer().as_bytes())
+			.gas_used(block.gas_used().try_into()?)
+			.maybe_last_commit_hash(block.header().last_commit_hash().map(|h| h.get().as_slice()))
+			.maybe_data_hash(block.header().data_hash().map(|h| h.get().as_slice()))
+			.maybe_last_results_hash(block.header().last_results_hash().map(|h| h.get().as_slice()))
+			.maybe_evidence_hash(block.header().evidence_hash().map(|h| h.get().as_slice()))
+			.build();
+
+		Ok(record)
+	}
+}
+
+impl<'a> TryFrom<&'a Tx> for NewTxRecord<'a> {
+	type Error = InvalidValueError;
+
+	fn try_from(tx_result: &'a Tx) -> Result<Self, Self::Error> {
+		let tx_record = NewTxRecord::builder()
+			.block_height(tx_result.block_height().get().try_into()?)
+			.tx_idx_in_block(tx_result.tx_idx_in_block().try_into()?)
+			.tx_hash(tx_result.tx_hash().get().as_slice())
+			.maybe_memo(tx_result.memo().map(AsRef::as_ref))
+			.maybe_timeout_height(
+				tx_result.timeout_height().map(|th| th.get().try_into()).transpose()?,
+			)
+			.signers(signer_keys_to_json(tx_result.signers().iter().cloned())?)
+			.payer(tx_result.payer().as_bytes())
+			.maybe_granter(tx_result.granter().map(Address::as_bytes))
+			.gas_limit(tx_result.gas_limit().try_into()?)
+			.gas_wanted(tx_result.gas_wanted().try_into()?)
+			.gas_used(tx_result.gas_used().try_into()?)
+			.code(tx_result.code().value().try_into()?)
+			.maybe_codespace(tx_result.codespace().map(AsRef::as_ref))
+			.maybe_data_bz(tx_result.data_bz().map(AsRef::as_ref))
+			.tx_bz(tx_result.tx_bz().get())
+			.build();
+
+		Ok(tx_record)
+	}
+}
+
+fn signer_keys_to_json<I>(keys: I) -> Result<Value, serde_json::Error>
+where
+	I: Iterator<Item = SignerPublicKey>,
+{
+	keys.map(Any::from).map(serde_json::to_value).collect::<Result<_, _>>().map(Value::Array)
+}

--- a/crates/imbibe-persistence/src/record/select.rs
+++ b/crates/imbibe-persistence/src/record/select.rs
@@ -1,0 +1,242 @@
+use bigdecimal::{BigDecimal, ToPrimitive};
+use bon::Builder;
+use chrono::{DateTime, Utc};
+use cosmrs::{
+	Any, Coin,
+	tx::{SignatureBytes, SignerPublicKey},
+};
+use diesel::prelude::Queryable;
+use imbibe_domain::{
+	Address, NonEmptyBz, Sha256,
+	block::{AppHash, Block, BlockData, Header},
+	tx::{Codespace, Fees, Memo, Tx},
+};
+use serde_json::Value;
+
+use super::error::InvalidValueError;
+
+#[derive(Debug, Queryable)]
+pub struct BlockWithDataRecord {
+	block: BlockRecord,
+	data: Vec<Vec<u8>>,
+}
+
+#[derive(Debug, Queryable)]
+pub struct BlockRecord {
+	height: i64,
+	block_hash: Vec<u8>,
+	chain_id: String,
+	time: DateTime<Utc>,
+	app_hash: Vec<u8>,
+	validators_hash: Vec<u8>,
+	next_validators_hash: Vec<u8>,
+	consensus_hash: Vec<u8>,
+	proposer: Vec<u8>,
+	gas_used: i64,
+	last_commit_hash: Option<Vec<u8>>,
+	data_hash: Option<Vec<u8>>,
+	last_results_hash: Option<Vec<u8>>,
+	evidence_hash: Option<Vec<u8>>,
+}
+
+#[derive(Debug, Builder)]
+pub struct TxWithDetailsRecord {
+	tx: TxRecord,
+	signatures: Vec<SignatureBytes>,
+	fees: Vec<Coin>,
+	msgs: Vec<Any>,
+}
+
+#[derive(Debug, Queryable)]
+pub struct TxRecord {
+	block_height: i64,
+	tx_idx_in_block: i64,
+	tx_hash: Vec<u8>,
+	memo: Option<String>,
+	timeout_height: Option<i64>,
+	signers: Value,
+	payer: Vec<u8>,
+	granter: Option<Vec<u8>>,
+	gas_limit: i64,
+	gas_wanted: i64,
+	gas_used: i64,
+	code: i32,
+	codespace: Option<String>,
+	data_bz: Option<Vec<u8>>,
+	tx_bz: Vec<u8>,
+}
+
+#[derive(Debug, Queryable)]
+pub struct SignatureRecord {
+	bz: Vec<u8>,
+}
+
+#[derive(Debug, Queryable)]
+pub struct FeeRecord {
+	amount: BigDecimal,
+	denom: String,
+}
+
+#[derive(Debug, Queryable)]
+pub struct MsgRecord {
+	type_url: String,
+	value: Vec<u8>,
+}
+
+impl TxRecord {
+	pub fn block_height(&self) -> i64 {
+		self.block_height
+	}
+
+	pub fn tx_idx_in_block(&self) -> i64 {
+		self.tx_idx_in_block
+	}
+}
+
+impl SignatureRecord {
+	pub fn into_bytes(self) -> SignatureBytes {
+		self.bz
+	}
+}
+
+impl TryFrom<BlockWithDataRecord> for Block {
+	type Error = InvalidValueError;
+
+	fn try_from(record: BlockWithDataRecord) -> Result<Self, Self::Error> {
+		let block_record = record.block;
+
+		let header = Header::builder()
+			.chain_id(block_record.chain_id)
+			.height(block_record.height.try_into()?)
+			.time(super::chrono_to_jiff(&block_record.time))
+			.validators_hash(Sha256::new(
+				block_record.validators_hash.as_slice().try_into()?,
+			))
+			.next_validators_hash(Sha256::new(
+				block_record.next_validators_hash.as_slice().try_into()?,
+			))
+			.consensus_hash(Sha256::new(
+				block_record.consensus_hash.as_slice().try_into()?,
+			))
+			.app_hash(AppHash::new(block_record.app_hash))
+			.proposer(Address::new(block_record.proposer.as_slice().try_into()?))
+			.maybe_last_commit_hash(
+				block_record
+					.last_commit_hash
+					.map(|h| h.as_slice().try_into().map(Sha256::new))
+					.transpose()?,
+			)
+			.maybe_data_hash(
+				block_record
+					.data_hash
+					.map(|h| h.as_slice().try_into().map(Sha256::new))
+					.transpose()?,
+			)
+			.maybe_last_results_hash(
+				block_record
+					.last_results_hash
+					.map(|h| h.as_slice().try_into().map(Sha256::new))
+					.transpose()?,
+			)
+			.maybe_evidence_hash(
+				block_record
+					.evidence_hash
+					.map(|h| h.as_slice().try_into().map(Sha256::new))
+					.transpose()?,
+			)
+			.build();
+
+		let block = Block::builder()
+			.header(header)
+			.hash(Sha256::new(block_record.block_hash.as_slice().try_into()?))
+			.gas_used(block_record.gas_used.try_into()?)
+			.data(
+				record
+					.data
+					.into_iter()
+					.map(From::from)
+					.map(NonEmptyBz::new)
+					.collect::<Option<_>>()
+					.and_then(BlockData::new)
+					.ok_or(InvalidValueError::Empty)?,
+			)
+			.build();
+
+		Ok(block)
+	}
+}
+
+impl TryFrom<TxWithDetailsRecord> for Tx {
+	type Error = InvalidValueError;
+
+	fn try_from(record: TxWithDetailsRecord) -> Result<Self, Self::Error> {
+		let txr = record.tx;
+		let tx = Tx::builder()
+			.block_height(u64::try_from(txr.block_height).and_then(|h| h.try_into())?)
+			.tx_idx_in_block(txr.tx_idx_in_block.try_into()?)
+			.tx_hash(
+				txr.tx_hash
+					.as_slice()
+					.try_into()
+					.map(Sha256::new)
+					.map_err(InvalidValueError::from)?,
+			)
+			.msgs(imbibe_domain::tx::Msgs::new(record.msgs).ok_or(InvalidValueError::Empty)?)
+			.maybe_memo(txr.memo.and_then(Memo::new))
+			.maybe_timeout_height(
+				txr.timeout_height
+					.map(u64::try_from)
+					.transpose()?
+					.map(TryFrom::try_from)
+					.transpose()?,
+			)
+			.signatures(record.signatures)
+			.maybe_fees(Fees::new(record.fees))
+			.signers(json_to_signer_keys(txr.signers)?)
+			.payer(txr.payer.as_slice().try_into().map(Address::new)?)
+			.maybe_granter(
+				txr.granter.as_deref().map(TryFrom::try_from).transpose()?.map(Address::new),
+			)
+			.code(u32::try_from(txr.code)?.into())
+			.maybe_codespace(txr.codespace.and_then(Codespace::new))
+			.gas_limit(txr.gas_limit.try_into()?)
+			.gas_wanted(txr.gas_wanted.try_into()?)
+			.gas_used(txr.gas_used.try_into()?)
+			.maybe_data_bz(txr.data_bz.map(From::from).and_then(NonEmptyBz::new))
+			.tx_bz(NonEmptyBz::new(txr.tx_bz.into()).ok_or(InvalidValueError::Empty)?)
+			.build();
+
+		Ok(tx)
+	}
+}
+
+impl TryFrom<&FeeRecord> for Coin {
+	type Error = InvalidValueError;
+
+	fn try_from(FeeRecord { amount, denom, .. }: &FeeRecord) -> Result<Self, Self::Error> {
+		amount
+			.to_u128()
+			.ok_or(InvalidValueError::AmountError)
+			.and_then(|amount| Coin::new(amount, denom).map_err(From::from))
+	}
+}
+
+impl From<MsgRecord> for Any {
+	fn from(MsgRecord { type_url, value, .. }: MsgRecord) -> Self {
+		Any { type_url, value }
+	}
+}
+
+fn json_to_signer_keys(json: Value) -> Result<Vec<SignerPublicKey>, InvalidValueError> {
+	match json {
+		Value::Array(keys) => keys
+			.into_iter()
+			.map(serde_json::from_value::<Any>)
+			.map(|any| any.map(SignerPublicKey::try_from).map_err(From::from))
+			.map(|spk| spk.and_then(|spk| spk.map_err(InvalidValueError::from)))
+			.collect(),
+		_ => Err(InvalidValueError::Other(
+			"signer keys must be array of keys".into(),
+		))?,
+	}
+}

--- a/crates/imbibe-persistence/src/schema.rs
+++ b/crates/imbibe-persistence/src/schema.rs
@@ -1,0 +1,82 @@
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    block (height) {
+        height -> Int8,
+        block_hash -> Bytea,
+        chain_id -> Text,
+        time -> Timestamptz,
+        app_hash -> Bytea,
+        validators_hash -> Bytea,
+        next_validators_hash -> Bytea,
+        consensus_hash -> Bytea,
+        proposer -> Bytea,
+        gas_used -> Int8,
+        last_commit_hash -> Nullable<Bytea>,
+        data_hash -> Nullable<Bytea>,
+        last_results_hash -> Nullable<Bytea>,
+        evidence_hash -> Nullable<Bytea>,
+    }
+}
+
+diesel::table! {
+    fee (block_height, tx_idx_in_block, fee_idx_in_tx) {
+        block_height -> Int8,
+        tx_idx_in_block -> Int8,
+        fee_idx_in_tx -> Int8,
+        amount -> Numeric,
+        denom -> Text,
+    }
+}
+
+diesel::table! {
+    msg (block_height, tx_idx_in_block, msg_idx_in_tx) {
+        block_height -> Int8,
+        tx_idx_in_block -> Int8,
+        msg_idx_in_tx -> Int8,
+        type_url -> Text,
+        value -> Bytea,
+    }
+}
+
+diesel::table! {
+    signature (block_height, tx_idx_in_block, signature_idx_in_tx) {
+        block_height -> Int8,
+        tx_idx_in_block -> Int8,
+        signature_idx_in_tx -> Int8,
+        bz -> Bytea,
+    }
+}
+
+diesel::table! {
+    tx (block_height, tx_idx_in_block) {
+        block_height -> Int8,
+        tx_idx_in_block -> Int8,
+        tx_hash -> Bytea,
+        memo -> Nullable<Text>,
+        timeout_height -> Nullable<Int8>,
+        signers -> Jsonb,
+        payer -> Bytea,
+        granter -> Nullable<Bytea>,
+        gas_limit -> Int8,
+        gas_wanted -> Int8,
+        gas_used -> Int8,
+        code -> Int4,
+        codespace -> Nullable<Text>,
+        data_bz -> Nullable<Bytea>,
+        tx_bz -> Bytea,
+    }
+}
+
+diesel::joinable!(fee -> block (block_height));
+diesel::joinable!(msg -> block (block_height));
+diesel::joinable!(signature -> block (block_height));
+diesel::joinable!(tx -> block (block_height));
+
+diesel::allow_tables_to_appear_in_same_query!(
+    block,
+    fee,
+    msg,
+    signature,
+    tx,
+);

--- a/crates/imbibe-persistence/src/store.rs
+++ b/crates/imbibe-persistence/src/store.rs
@@ -1,0 +1,343 @@
+mod error;
+
+pub use crate::record::error::InvalidValueError;
+
+pub use self::error::StoreError;
+
+use core::num::NonZeroU64;
+
+use diesel::{
+	ExpressionMethods, JoinOnDsl, QueryDsl, dsl,
+	prelude::QueryableByName,
+	sql_types::{Array, BigInt, Bytea},
+};
+use diesel_async::{AsyncConnection, RunQueryDsl, scoped_futures::ScopedFutureExt};
+use futures::{Stream, StreamExt, TryStreamExt};
+use imbibe_domain::{
+	Sha256,
+	block::Block,
+	tx::{Fees, Tx},
+};
+
+use crate::pool::DbConn;
+
+use super::{
+	record::{
+		insert::{NewBlockRecord, NewFeeRecord, NewMsgRecord, NewSignatureRecord, NewTxRecord},
+		select::{
+			BlockWithDataRecord, FeeRecord, MsgRecord, SignatureRecord, TxRecord,
+			TxWithDetailsRecord,
+		},
+	},
+	schema,
+};
+
+use self::error::Result;
+
+#[tracing::instrument(skip_all)]
+pub async fn save_blocks_with_txs<TXS>(
+	conn: &mut DbConn,
+	blocks_with_txs: &[(Block, TXS)],
+) -> Result<()>
+where
+	TXS: AsRef<[Tx]>,
+{
+	let mut new_block_records = Vec::with_capacity(blocks_with_txs.len());
+	let mut new_tx_records = vec![];
+	let mut new_signature_records = vec![];
+	let mut new_fee_records = vec![];
+	let mut new_msg_records = vec![];
+
+	for (block, txs) in blocks_with_txs {
+		new_block_records.push(NewBlockRecord::try_from(block)?);
+
+		process_new_records_from_txs(
+			txs.as_ref(),
+			&mut new_tx_records,
+			&mut new_signature_records,
+			&mut new_fee_records,
+			&mut new_msg_records,
+		)?;
+	}
+
+	conn.transaction(|conn| {
+		async move {
+			diesel::insert_into(schema::block::table)
+				.values(new_block_records)
+				.execute(conn)
+				.await?;
+
+			diesel::insert_into(schema::tx::table).values(new_tx_records).execute(conn).await?;
+			diesel::insert_into(schema::signature::table)
+				.values(new_signature_records)
+				.execute(conn)
+				.await?;
+			diesel::insert_into(schema::fee::table).values(new_fee_records).execute(conn).await?;
+			diesel::insert_into(schema::msg::table).values(new_msg_records).execute(conn).await?;
+
+			Result::<_, StoreError>::Ok(())
+		}
+		.scope_boxed()
+	})
+	.await?;
+
+	Ok(())
+}
+
+#[tracing::instrument(skip_all)]
+pub async fn save_block_with_txs(conn: &mut DbConn, block: &Block, txs: &[Tx]) -> Result<()> {
+	let new_block_record = NewBlockRecord::try_from(block)?;
+
+	let mut new_tx_records = Vec::with_capacity(txs.len());
+	let mut new_signature_records = vec![];
+	let mut new_fee_records = vec![];
+	let mut new_msg_records = vec![];
+
+	process_new_records_from_txs(
+		txs,
+		&mut new_tx_records,
+		&mut new_signature_records,
+		&mut new_fee_records,
+		&mut new_msg_records,
+	)?;
+
+	conn.transaction(|conn| {
+		async move {
+			diesel::insert_into(schema::block::table)
+				.values(new_block_record)
+				.execute(conn)
+				.await?;
+
+			diesel::insert_into(schema::tx::table).values(new_tx_records).execute(conn).await?;
+			diesel::insert_into(schema::signature::table)
+				.values(new_signature_records)
+				.execute(conn)
+				.await?;
+			diesel::insert_into(schema::fee::table).values(new_fee_records).execute(conn).await?;
+			diesel::insert_into(schema::msg::table).values(new_msg_records).execute(conn).await?;
+
+			Result::<_, StoreError>::Ok(())
+		}
+		.scope_boxed()
+	})
+	.await?;
+
+	Ok(())
+}
+
+#[tracing::instrument(skip(conn))]
+pub async fn fetch_missing_block_heights(
+	conn: &mut DbConn,
+	lo: NonZeroU64,
+	hi: NonZeroU64,
+) -> Result<impl Stream<Item = Result<NonZeroU64>>> {
+	#[derive(QueryableByName)]
+	struct MissingHeight {
+		#[diesel(sql_type = BigInt)]
+		height: i64,
+	}
+
+	const SQL: &str = r#"
+		SELECT gs.height
+		FROM generate_series($1, $2) AS gs(height)
+		LEFT JOIN block ON block.height = gs.height
+		WHERE block.height IS NULL
+	"#;
+
+	let stream = diesel::sql_query(SQL)
+		.bind::<BigInt, _>(i64::try_from(lo.get()).map_err(InvalidValueError::from)?)
+		.bind::<BigInt, _>(i64::try_from(hi.get()).map_err(InvalidValueError::from)?)
+		.load_stream::<MissingHeight>(conn)
+		.await?
+		.map_ok(|h| h.height)
+		.map_ok(u64::try_from)
+		.map_ok(|h| h.and_then(TryFrom::try_from).map_err(InvalidValueError::from))
+		.map_err(From::from)
+		.map(|h| h.and_then(|h| h.map_err(From::from)));
+
+	Ok(stream)
+}
+
+#[tracing::instrument(skip(conn))]
+pub async fn fetch_block_by_height(conn: &mut DbConn, height: NonZeroU64) -> Result<Block> {
+	let tx_bz_array_agg = dsl::sql::<Array<Bytea>>(
+		"COALESCE(NULLIF(array_agg(tx.tx_bz ORDER BY tx.tx_idx_in_block ASC), '{NULL}'), '{}')",
+	);
+
+	schema::block::table
+		.left_join(schema::tx::table.on(schema::tx::block_height.eq(schema::block::height)))
+		.filter(
+			schema::block::height.eq(i64::try_from(height.get()).map_err(InvalidValueError::from)?),
+		)
+		.select((schema::block::all_columns, tx_bz_array_agg))
+		.group_by(schema::block::all_columns)
+		.first::<BlockWithDataRecord>(conn)
+		.await
+		.map(TryFrom::try_from)?
+		.map_err(From::from)
+}
+
+#[tracing::instrument(skip(conn))]
+pub async fn fetch_block_by_block_hash(conn: &mut DbConn, block_hash: &Sha256) -> Result<Block> {
+	let tx_bz_array_agg =
+		dsl::sql::<Array<Bytea>>("array_agg(tx.tx_bz ORDER BY tx.tx_idx_in_block ASC)");
+
+	schema::block::table
+		.left_join(schema::tx::table.on(schema::tx::block_height.eq(schema::block::height)))
+		.filter(schema::block::block_hash.eq(block_hash.get()))
+		.select((schema::block::all_columns, tx_bz_array_agg))
+		.group_by(schema::block::all_columns)
+		.first::<BlockWithDataRecord>(conn)
+		.await
+		.map(TryFrom::try_from)?
+		.map_err(From::from)
+}
+
+#[tracing::instrument(skip(conn))]
+pub async fn fetch_tx_by_block_height_and_tx_idx_in_block(
+	conn: &mut DbConn,
+	height: NonZeroU64,
+	tx_idx_in_block: u64,
+) -> Result<Tx> {
+	let height = i64::try_from(height.get()).map_err(InvalidValueError::from)?;
+	let tx_idx_in_block = i64::try_from(tx_idx_in_block).map_err(InvalidValueError::from)?;
+
+	let tx = schema::tx::table
+		.select(schema::tx::all_columns)
+		.filter(schema::tx::block_height.eq(height))
+		.filter(schema::tx::tx_idx_in_block.eq(tx_idx_in_block))
+		.first(conn)
+		.await?;
+
+	let signatures = fetch_signatures(conn, height, tx_idx_in_block).await?;
+	let fee = fetch_fee(conn, height, tx_idx_in_block).await?;
+	let msgs = fetch_msgs(conn, height, tx_idx_in_block).await?;
+
+	TxWithDetailsRecord::builder()
+		.tx(tx)
+		.signatures(signatures.into_iter().map(SignatureRecord::into_bytes).collect())
+		.msgs(msgs.into_iter().map(From::from).collect())
+		.fees(fee.iter().map(TryFrom::try_from).collect::<Result<_, _>>()?)
+		.build()
+		.try_into()
+		.map_err(From::from)
+}
+
+#[tracing::instrument(skip(conn))]
+pub async fn fetch_tx_by_tx_hash(conn: &mut DbConn, tx_hash: &Sha256) -> Result<Tx> {
+	let tx = schema::tx::table
+		.select(schema::tx::all_columns)
+		.filter(schema::tx::tx_hash.eq(tx_hash.get()))
+		.first::<TxRecord>(conn)
+		.await?;
+
+	let height = tx.block_height();
+	let tx_idx_in_block = tx.tx_idx_in_block();
+
+	let signatures = fetch_signatures(conn, height, tx_idx_in_block).await?;
+	let fee = fetch_fee(conn, height, tx_idx_in_block).await?;
+	let msgs = fetch_msgs(conn, height, tx_idx_in_block).await?;
+
+	TxWithDetailsRecord::builder()
+		.tx(tx)
+		.signatures(signatures.into_iter().map(SignatureRecord::into_bytes).collect())
+		.msgs(msgs.into_iter().map(From::from).collect())
+		.fees(fee.iter().map(TryFrom::try_from).collect::<Result<_, _>>()?)
+		.build()
+		.try_into()
+		.map_err(From::from)
+}
+
+fn process_new_records_from_txs<'a>(
+	txs: &'a [Tx],
+	new_tx_records: &mut Vec<NewTxRecord<'a>>,
+	new_signature_records: &mut Vec<NewSignatureRecord<'a>>,
+	new_fee_records: &mut Vec<NewFeeRecord<'a>>,
+	new_msg_records: &mut Vec<NewMsgRecord<'a>>,
+) -> Result<(), InvalidValueError> {
+	for tx in txs {
+		new_tx_records.push(tx.try_into()?);
+
+		let block_height = tx.block_height().get().try_into()?;
+		let tx_idx_in_block = tx.tx_idx_in_block().try_into()?;
+
+		for (idx, signature) in tx.signatures().iter().enumerate() {
+			let signature_record = NewSignatureRecord::builder()
+				.block_height(block_height)
+				.tx_idx_in_block(tx_idx_in_block)
+				.signature_idx_in_tx(idx.try_into()?)
+				.bz(signature)
+				.build();
+
+			new_signature_records.push(signature_record);
+		}
+
+		for (idx, coin) in tx.fees().map(Fees::get).into_iter().flatten().enumerate() {
+			let fee_record = NewFeeRecord::builder()
+				.block_height(block_height)
+				.tx_idx_in_block(tx_idx_in_block)
+				.fee_idx_in_tx(idx.try_into()?)
+				.amount(coin.amount.into())
+				.denom(coin.denom.as_ref())
+				.build();
+
+			new_fee_records.push(fee_record);
+		}
+
+		for (idx, msg) in tx.msgs().get().iter().enumerate() {
+			let msg_record = NewMsgRecord::builder()
+				.block_height(block_height)
+				.tx_idx_in_block(tx_idx_in_block)
+				.msg_idx_in_tx(idx.try_into()?)
+				.type_url(&msg.type_url)
+				.value(&msg.value)
+				.build();
+
+			new_msg_records.push(msg_record);
+		}
+	}
+
+	Ok(())
+}
+
+async fn fetch_signatures(
+	conn: &mut DbConn,
+	height: i64,
+	tx_idx_in_block: i64,
+) -> Result<Vec<SignatureRecord>, diesel::result::Error> {
+	schema::signature::table
+		.select((schema::signature::bz,))
+		.filter(schema::signature::block_height.eq(height))
+		.filter(schema::signature::tx_idx_in_block.eq(tx_idx_in_block))
+		.order(schema::signature::signature_idx_in_tx.asc())
+		.load(conn)
+		.await
+}
+
+async fn fetch_fee(
+	conn: &mut DbConn,
+	height: i64,
+	tx_idx_in_block: i64,
+) -> Result<Vec<FeeRecord>, diesel::result::Error> {
+	schema::fee::table
+		.select((schema::fee::amount, schema::fee::denom))
+		.filter(schema::fee::block_height.eq(height))
+		.filter(schema::fee::tx_idx_in_block.eq(tx_idx_in_block))
+		.order(schema::fee::fee_idx_in_tx.asc())
+		.load(conn)
+		.await
+}
+
+async fn fetch_msgs(
+	conn: &mut DbConn,
+	height: i64,
+	tx_idx_in_block: i64,
+) -> Result<Vec<MsgRecord>, diesel::result::Error> {
+	schema::msg::table
+		.select((schema::msg::type_url, schema::msg::value))
+		.filter(schema::msg::block_height.eq(height))
+		.filter(schema::msg::tx_idx_in_block.eq(tx_idx_in_block))
+		.order(schema::msg::msg_idx_in_tx.asc())
+		.load(conn)
+		.await
+}

--- a/crates/imbibe-persistence/src/store/error.rs
+++ b/crates/imbibe-persistence/src/store/error.rs
@@ -1,0 +1,12 @@
+use crate::record::error::InvalidValueError;
+
+pub type Result<T, E = StoreError> = core::result::Result<T, E>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum StoreError {
+	#[error("db error: {0}")]
+	Db(#[from] diesel::result::Error),
+
+	#[error("invalid value error: {0}")]
+	InvalidValue(#[from] InvalidValueError),
+}


### PR DESCRIPTION
- use diesel-async to support async operations
- add capability to hold a pooled connection with the Postgresql database
- Use diesel's query builders to ensure compile-time safety of queriers