### PR TITLE
add tarpc querier capability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ cosmrs = "0.22"
 futures = "0.3"
 jiff = "0.2"
 serde = "1"
+tarpc = "0.36"
 thiserror = "2"
 tokio = "1"
 tracing = "0.1"
-

--- a/crates/imbibe-domain/Cargo.toml
+++ b/crates/imbibe-domain/Cargo.toml
@@ -23,4 +23,3 @@ cosmrs = { workspace = true }
 jiff = { workspace = true }
 serde = { workspace = true, optional = true, features = ["derive"] }
 thiserror = { workspace = true }
-

--- a/crates/imbibe-persistence/src/lib.rs
+++ b/crates/imbibe-persistence/src/lib.rs
@@ -2,4 +2,6 @@ pub mod pool;
 pub mod store;
 
 mod record;
+
+#[rustfmt::skip]
 mod schema;

--- a/crates/imbibe-persistence/src/store.rs
+++ b/crates/imbibe-persistence/src/store.rs
@@ -179,8 +179,9 @@ pub async fn fetch_block_by_height(conn: &mut DbConn, height: NonZeroU64) -> Res
 
 #[tracing::instrument(skip(conn))]
 pub async fn fetch_block_by_block_hash(conn: &mut DbConn, block_hash: &Sha256) -> Result<Block> {
-	let tx_bz_array_agg =
-		dsl::sql::<Array<Bytea>>("array_agg(tx.tx_bz ORDER BY tx.tx_idx_in_block ASC)");
+	let tx_bz_array_agg = dsl::sql::<Array<Bytea>>(
+		"COALESCE(NULLIF(array_agg(tx.tx_bz ORDER BY tx.tx_idx_in_block ASC), '{NULL}'), '{}')",
+	);
 
 	schema::block::table
 		.left_join(schema::tx::table.on(schema::tx::block_height.eq(schema::block::height)))

--- a/crates/imbibe-protos/src/lib.rs
+++ b/crates/imbibe-protos/src/lib.rs
@@ -4,82 +4,88 @@ mod error;
 pub use imbibe_macros::GetSigners;
 
 #[cfg(feature = "protogen")]
-pub use self::error::ProtosError;
+pub use self::{codegen::*, error::ProtosError, signer_extractor::*};
 
-#[allow(unused_macros)]
-#[cfg(feature = "protogen")]
-macro_rules! generate_signer_extractors {
-	(
-		$(($type_url:literal, $rust_struct:path)),* $(,)?
-	) => {
-		pub fn signers_from_any_msg(
-			msg: &::cosmrs::Any,
-		) -> Result<Box<dyn Iterator<Item = String>>, error::ProtosError> {
-			match msg.type_url.as_str() {
-				$(
-					$type_url => {
-						::cosmrs::Any::to_msg::<$rust_struct>(msg)
-							.map(GetSigners::signers)
-							.map(|signers| Box::new(signers) as Box<dyn Iterator<Item = String>>)
-							.map_err(From::from)
-					},
-				)*
-				_ => Err(error::ProtosError::NoSignerInMsg { type_url: msg.type_url.clone() }),
-			}
-		}
-
-		#[allow(unused_variables)]
-		pub fn extend_with_signers_from_any_msg<E>(
-			msg: &::cosmrs::Any,
-			signers: &mut E,
-		) -> Result<(), error::ProtosError>
-		where
-			E: ::std::iter::Extend<String>,
-		{
-			match msg.type_url.as_str() {
-				$(
-					$type_url => {
-						::cosmrs::Any::to_msg::<$rust_struct>(msg)
-							.map(GetSigners::signers)
-							.map(|s| ::std::iter::Extend::extend(signers, s))
-							.map_err(From::from)
-					},
-				)*
-				_ => Err(error::ProtosError::NoSignerInMsg { type_url: msg.type_url.clone() }),
-			}
-		}
-
-		pub fn unique_signers_from_any_msg(
-			msg: &::cosmrs::Any,
-		) -> Result<::std::collections::HashSet<String>, error::ProtosError>
-		{
-			let mut unique_signers = std::collections::HashSet::new();
-			extend_with_signers_from_any_msg(msg, &mut unique_signers)?;
-
-			Ok(unique_signers)
-		}
-
-		pub fn unique_signers_from_any_msgs<'a, I>(
-			msgs: I,
-		) -> Result<::std::collections::HashSet<String>, error::ProtosError>
-		where
-			I: IntoIterator<Item = &'a cosmrs::Any> + 'a,
-		{
-			let mut unique_signers = std::collections::HashSet::new();
-			msgs.into_iter()
-				.map(|msg| extend_with_signers_from_any_msg(msg, &mut unique_signers))
-				.collect::<Result<(), _>>()?;
-
-			Ok(unique_signers)
-		}
-	};
+#[allow(clippy::doc_overindented_list_items, clippy::doc_lazy_continuation)]
+mod codegen {
+	#[cfg(feature = "protogen")]
+	include!(concat!(env!("OUT_DIR"), "/code_gen/mod.rs"));
 }
 
 #[cfg(feature = "protogen")]
-include!(concat!(env!("OUT_DIR"), "/any_signer_extractor.rs"));
+mod signer_extractor {
+	use super::{GetSigners, codegen::*, error};
 
-#[cfg(feature = "protogen")]
-include!(concat!(env!("OUT_DIR"), "/code_gen/mod.rs"));
+	macro_rules! generate_signer_extractors {
+		(
+			$(($type_url:literal, $rust_struct:path)),* $(,)?
+		) => {
+			pub fn signers_from_any_msg(
+				msg: &::cosmrs::Any,
+			) -> Result<Box<dyn Iterator<Item = String>>, error::ProtosError> {
+				match msg.type_url.as_str() {
+					$(
+						$type_url => {
+							::cosmrs::Any::to_msg::<$rust_struct>(msg)
+								.map(GetSigners::signers)
+								.map(|signers| Box::new(signers) as Box<dyn Iterator<Item = String>>)
+								.map_err(From::from)
+						},
+					)*
+					_ => Err(error::ProtosError::NoSignerInMsg { type_url: msg.type_url.clone() }),
+				}
+			}
+
+			#[allow(unused_variables)]
+			pub fn extend_with_signers_from_any_msg<E>(
+				msg: &::cosmrs::Any,
+				signers: &mut E,
+			) -> Result<(), error::ProtosError>
+			where
+				E: ::std::iter::Extend<String>,
+			{
+				match msg.type_url.as_str() {
+					$(
+						$type_url => {
+							::cosmrs::Any::to_msg::<$rust_struct>(msg)
+								.map(GetSigners::signers)
+								.map(|s| ::std::iter::Extend::extend(signers, s))
+								.map_err(From::from)
+						},
+					)*
+					_ => Err(error::ProtosError::NoSignerInMsg { type_url: msg.type_url.clone() }),
+				}
+			}
+
+			pub fn unique_signers_from_any_msg(
+				msg: &::cosmrs::Any,
+			) -> Result<::std::collections::HashSet<String>, error::ProtosError>
+			{
+				let mut unique_signers = std::collections::HashSet::new();
+				extend_with_signers_from_any_msg(msg, &mut unique_signers)?;
+
+				Ok(unique_signers)
+			}
+
+			pub fn unique_signers_from_any_msgs<'a, I>(
+				msgs: I,
+			) -> Result<::std::collections::HashSet<String>, error::ProtosError>
+			where
+				I: IntoIterator<Item = &'a cosmrs::Any> + 'a,
+			{
+				let mut unique_signers = std::collections::HashSet::new();
+				msgs.into_iter()
+					.map(|msg| extend_with_signers_from_any_msg(msg, &mut unique_signers))
+					.collect::<Result<(), _>>()?;
+
+				Ok(unique_signers)
+			}
+		};
+	}
+
+	#[cfg(feature = "protogen")]
+	include!(concat!(env!("OUT_DIR"), "/any_signer_extractor.rs"));
+}
 
 pub trait GetSigners {
 	type Signer;

--- a/crates/imbibe-querier/Cargo.toml
+++ b/crates/imbibe-querier/Cargo.toml
@@ -10,11 +10,20 @@ workspace = true
 
 [features]
 default = []
+tarpc = [
+  "dep:serde",
+  "dep:tarpc",
+  "dep:tokio",
+  "imbibe-domain/serde",
+]
 
 [dependencies]
 bon = { workspace = true }
 imbibe-domain = { workspace = true }
 imbibe-persistence = { workspace = true }
-tracing = { workspace = true }
+serde = { workspace = true, optional = true, features = ["derive"] }
+tarpc = { workspace = true, optional = true }
 thiserror = { workspace = true }
+tokio = { workspace = true, optional = true, features = ["time"] }
+tracing = { workspace = true }
 

--- a/crates/imbibe-querier/README.md
+++ b/crates/imbibe-querier/README.md
@@ -6,3 +6,7 @@ This crate provides `Querier` that holds a database connection pool, and provide
 - fetch block by block hash
 - fetch tx by block height and the tx index in block
 - fetch tx by tx hash 
+
+## tarpc
+
+If `tarpc` feature is enabled, this crate also provides a [tarpc](github.com/google/tarpc) server and client implementation to facilitate the queries across a network.

--- a/crates/imbibe-querier/src/lib.rs
+++ b/crates/imbibe-querier/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "tarpc")]
+pub mod tarpc;
+
 mod error;
 
 pub use self::error::QuerierError;

--- a/crates/imbibe-querier/src/tarpc.rs
+++ b/crates/imbibe-querier/src/tarpc.rs
@@ -1,0 +1,87 @@
+mod error;
+
+pub use self::error::{QueryTarpcError, Result};
+
+use std::{num::NonZeroU64, time::Instant};
+
+use bon::Builder;
+use imbibe_domain::{Sha256, block::Block, tx::Tx};
+use tarpc::context::Context;
+
+use crate::Querier;
+
+use self::error::QueryTarpcErrorKind;
+
+#[tarpc::service]
+pub trait Query {
+	async fn block_by_height(height: NonZeroU64) -> Result<Block>;
+
+	async fn block_by_block_hash(block_hash: Sha256) -> Result<Block>;
+
+	async fn tx_by_block_height_and_tx_idx_in_block(
+		height: NonZeroU64,
+		tx_idx_in_block: u64,
+	) -> Result<Tx>;
+
+	async fn tx_by_tx_hash(tx_hash: Sha256) -> Result<Tx>;
+}
+
+#[derive(Clone, Builder)]
+pub struct QueryServer {
+	querier: Querier,
+}
+
+impl Query for QueryServer {
+	async fn block_by_height(self, ctx: Context, height: NonZeroU64) -> Result<Block> {
+		tokio::time::timeout(
+			ctx.deadline.saturating_duration_since(Instant::now()),
+			self.querier.get_block_by_height(height),
+		)
+		.await
+		.map_err(QueryTarpcErrorKind::from)
+		.and_then(|r| r.map_err(From::from))
+		.inspect_err(|e| tracing::error!("{e}"))
+		.map_err(From::from)
+	}
+
+	async fn block_by_block_hash(self, ctx: Context, block_hash: Sha256) -> Result<Block> {
+		tokio::time::timeout(
+			ctx.deadline.saturating_duration_since(Instant::now()),
+			self.querier.get_block_by_block_hash(&block_hash),
+		)
+		.await
+		.map_err(QueryTarpcErrorKind::from)
+		.and_then(|r| r.map_err(From::from))
+		.inspect_err(|e| tracing::error!("{e}"))
+		.map_err(From::from)
+	}
+
+	async fn tx_by_block_height_and_tx_idx_in_block(
+		self,
+		ctx: Context,
+		height: NonZeroU64,
+		tx_idx_in_block: u64,
+	) -> Result<Tx> {
+		tokio::time::timeout(
+			ctx.deadline.saturating_duration_since(Instant::now()),
+			self.querier.get_tx_by_block_height_and_tx_idx_in_block(height, tx_idx_in_block),
+		)
+		.await
+		.map_err(QueryTarpcErrorKind::from)
+		.and_then(|r| r.map_err(From::from))
+		.map_err(From::from)
+		.inspect_err(|e| tracing::error!("{e}"))
+	}
+
+	async fn tx_by_tx_hash(self, ctx: Context, tx_hash: Sha256) -> Result<Tx> {
+		tokio::time::timeout(
+			ctx.deadline.saturating_duration_since(Instant::now()),
+			self.querier.get_tx_by_tx_hash(&tx_hash),
+		)
+		.await
+		.map_err(QueryTarpcErrorKind::from)
+		.and_then(|r| r.map_err(From::from))
+		.map_err(From::from)
+		.inspect_err(|e| tracing::error!("{e}"))
+	}
+}

--- a/crates/imbibe-querier/src/tarpc/error.rs
+++ b/crates/imbibe-querier/src/tarpc/error.rs
@@ -1,0 +1,26 @@
+use serde::{Deserialize, Serialize};
+
+use crate::QuerierError;
+
+pub type Result<T, E = QueryTarpcError> = core::result::Result<T, E>;
+
+#[derive(Debug, thiserror::Error, Serialize, Deserialize)]
+#[error("{msg}")]
+pub struct QueryTarpcError {
+	msg: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(super) enum QueryTarpcErrorKind {
+	#[error("timeout error: {0}")]
+	Timeout(#[from] tokio::time::error::Elapsed),
+
+	#[error("querier error: {0}")]
+	Querier(#[from] QuerierError),
+}
+
+impl From<QueryTarpcErrorKind> for QueryTarpcError {
+	fn from(err: QueryTarpcErrorKind) -> Self {
+		Self { msg: err.to_string() }
+	}
+}

--- a/crates/imbibed/Cargo.toml
+++ b/crates/imbibed/Cargo.toml
@@ -9,7 +9,7 @@ publish.workspace = true
 workspace = true
 
 [features]
-default = []
+default = ["tarpc-querier"]
 bundled = ["imbibe-persistence/bundled"]
 custom-protos = ["imbibe-indexer/custom-protos"]
 disable-telemetry = ["disable-tracing"]
@@ -18,14 +18,32 @@ disable-tracing = [
   "tracing/release_max_level_off",
 ]
 ethsecp256k1 = ["imbibe-indexer/ethsecp256k1"]
+indexer = [
+  "dep:imbibe-indexer",
+  "persistence",
+]
+persistence = ["dep:imbibe-persistence"]
+querier = [
+  "dep:imbibe-querier",
+  "persistence",
+]
+tarpc-querier = [
+  "dep:futures",
+  "dep:tarpc",
+  "imbibe-querier/tarpc",
+  "querier",
+]
 
 [dependencies]
 anyhow = "1"
 config = { version = "0.15", default-features = false, features = ["ron"] }
-imbibe-indexer = { workspace = true }
-imbibe-persistence = { workspace = true }
+futures = { workspace = true, optional = true }
+imbibe-indexer = { workspace = true, optional = true }
+imbibe-persistence = { workspace = true, optional = true }
+imbibe-querier = { workspace = true, optional = true }
 imbibe-telemetry = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+tarpc = { workspace = true, optional = true, features = ["serde-transport-json", "tcp"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/imbibed/src/base_config.ron
+++ b/crates/imbibed/src/base_config.ron
@@ -11,6 +11,9 @@ Config(
 	    batch: 1000,
 	    workers: 100,
     ),
+    querier: QuerierConfig (
+        listen: "localhost:18181",
+    ),
     telemetry: TelemetryConfig(
         trace_exporter: "http://localhost:4317",
         timeout_millis: 5000,

--- a/crates/imbibed/src/config.rs
+++ b/crates/imbibed/src/config.rs
@@ -1,5 +1,3 @@
-use core::num::NonZeroUsize;
-
 use config::{ConfigError, Environment, File, FileFormat};
 use serde::Deserialize;
 
@@ -7,9 +5,14 @@ use serde::Deserialize;
 pub struct Config {
 	pub app: AppConfig,
 
+	#[cfg(feature = "persistence")]
 	pub db: DbConfig,
 
+	#[cfg(feature = "indexer")]
 	pub indexer: IndexerConfig,
+
+	#[cfg(feature = "querier")]
+	pub querier: QuerierConfig,
 
 	#[cfg(not(feature = "disable-telemetry"))]
 	pub telemetry: TelemetryConfig,
@@ -20,17 +23,25 @@ pub struct AppConfig {
 	pub name: String,
 }
 
+#[cfg(feature = "persistence")]
 #[derive(Deserialize)]
 pub struct DbConfig {
 	pub db_url: String,
-	pub max_conn: NonZeroUsize,
+	pub max_conn: core::num::NonZeroUsize,
 }
 
+#[cfg(feature = "indexer")]
 #[derive(Deserialize)]
 pub struct IndexerConfig {
 	pub tm_ws_url: String,
-	pub batch: NonZeroUsize,
-	pub workers: NonZeroUsize,
+	pub batch: core::num::NonZeroUsize,
+	pub workers: core::num::NonZeroUsize,
+}
+
+#[cfg(feature = "querier")]
+#[derive(Deserialize)]
+pub struct QuerierConfig {
+	pub listen: String,
 }
 
 #[cfg(not(feature = "disable-telemetry"))]

--- a/crates/imbibed/src/lib.rs
+++ b/crates/imbibed/src/lib.rs
@@ -1,2 +1,7 @@
 pub mod config;
+
+#[cfg(feature = "indexer")]
 pub mod indexer;
+
+#[cfg(feature = "tarpc-querier")]
+pub mod tarpc_querier;

--- a/crates/imbibed/src/tarpc_querier.rs
+++ b/crates/imbibed/src/tarpc_querier.rs
@@ -1,0 +1,43 @@
+use core::future;
+
+use futures::StreamExt;
+use imbibe_persistence::pool::DbPool;
+use imbibe_querier::{
+	Querier,
+	tarpc::{Query, QueryServer},
+};
+use tarpc::{
+	server::{BaseChannel, Channel, incoming::Incoming},
+	tokio_serde::formats::Json,
+};
+use tokio::net::ToSocketAddrs;
+
+pub async fn run<A>(pool: DbPool, sock_addr: A) -> anyhow::Result<()>
+where
+	A: ToSocketAddrs,
+{
+	let listener = tarpc::serde_transport::tcp::listen(sock_addr, Json::default).await?;
+
+	tracing::info!(
+		"querier tarpc listening port {}",
+		listener.local_addr().port()
+	);
+
+	let querier = Querier::builder().pool(pool).build();
+	let rpc = listener
+		.filter_map(|r| future::ready(r.ok()))
+		.map(BaseChannel::with_defaults)
+		.max_channels_per_key(1, |t| t.transport().peer_addr().unwrap().ip())
+		.map(move |channel| {
+			let server = QueryServer::builder().querier(querier.clone()).build();
+			channel.execute(server.serve()).for_each(async |r| {
+				tokio::spawn(r);
+			})
+		})
+		.buffer_unordered(10)
+		.for_each(async |_| {});
+
+	tokio::spawn(rpc).await?;
+
+	Ok(())
+}


### PR DESCRIPTION
- separate indexer and tarpc-querier functionalities behind feature flags `indexer` and `tarpc-querier`.
- fix store method `fetch_block_by_block_hash` (query failed when block had no tx) in imbibe-persistence
- change module structure in `imbibe-protos` to suppress clippy lints.