### PR TITLE
enable the publishing of imbibe crates to the registry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ version = "0.0.1"
 edition = "2024"
 repository = "https://github.com/labcycle/imbibe"
 license = "Apache-2.0"
-publish = false
+publish = true
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/crates/imbibed/Cargo.toml
+++ b/crates/imbibed/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
-name = "imbibed"
+name = "imbibe"
 version.workspace = true
 edition.workspace = true
 readme = "README.md"
+description = "a cosmos chain indexer"
 repository.workspace = true
 license.workspace = true
 publish.workspace = true

--- a/crates/imbibed/src/main.rs
+++ b/crates/imbibed/src/main.rs
@@ -1,4 +1,4 @@
-use imbibed::config;
+use imbibe::config;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -19,7 +19,7 @@ async fn main() -> anyhow::Result<()> {
 
 	#[cfg(feature = "indexer")]
 	let indexer_handle = {
-		let indexer = imbibed::indexer::run(
+		let indexer = imbibe::indexer::run(
 			config.indexer.tm_ws_url,
 			pool.clone(),
 			config.indexer.batch,
@@ -31,7 +31,7 @@ async fn main() -> anyhow::Result<()> {
 
 	#[cfg(feature = "tarpc-querier")]
 	let tarpc_querier_handle = {
-		let tarpc_querier = imbibed::tarpc_querier::run(pool, config.querier.listen);
+		let tarpc_querier = imbibe::tarpc_querier::run(pool, config.querier.listen);
 
 		tokio::spawn(tarpc_querier)
 	};


### PR DESCRIPTION
- rename `imbibed` crate to `imbibe`.